### PR TITLE
Refactor MLP testbench to use a loop for memory file loading

### DIFF
--- a/sim/mlp_tb.v
+++ b/sim/mlp_tb.v
@@ -104,6 +104,7 @@ module mlp_tb;
     integer sigmoid_file;
     reg signed [22:0] parameters [0:260];
     reg signed [15:0] targets [0:19];
+    reg [8*128:1] fname;
 
     initial begin
         // Initialize Inputs
@@ -112,8 +113,6 @@ module mlp_tb;
         clock = 0;
         reset = 1;
         #10;
-
-
 
         // Load the parameters (wights and bias) data from memory files
         $readmemb("../mem/central_barrel/eta1/et6/q15_params_et6_eta1.mem", parameters);
@@ -140,383 +139,27 @@ module mlp_tb;
         linear_file = $fopen("../mem/central_barrel/eta1/et6/et6_eta1_output_linear.txt", "w");
         sigmoid_file = $fopen("../mem/central_barrel/eta1/et6/et6_eta1_output_sigmoid.txt", "w");
 
-        $readmemb("../mem/central_barrel/eta1/et6/rings_data_0_et6_eta1.mem", inputs);
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
 
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
+        for (i = 0; i < 20; i = i + 1) begin
+            // Load the inputs data from memory files
+            $swrite(fname, "../mem/central_barrel/eta1/et6/rings_data_%0d_et6_eta1.mem", i);
+            $readmemb(fname, inputs);
+
+            repeat (2) begin
+                // Generate a positive impulse on clock
+                clock = 1; 
+                #10;
+                clock = 0; 
+                #50;
+            end
+
+            // Display the output
+            $display("Antes %0d: %f \t Output %0d: %f \t Target %0d: %d", 
+                    i, out_1_sig/32768.0, i, out/32768.0, i, targets[i]);
+            $fwrite(linear_file,  "%f\n", out_1_sig/32768.0);
+            $fwrite(sigmoid_file, "%f\n", out/32768.0);
+        end
 
-        // Display the output
-        $display("Antes 0: %f \t Output 0: %f \t Target 0: %d",out_1_sig/32768.0, out/32768.0, targets[0]);
-        $fwrite(linear_file,"%f\n", out_1_sig/32768.0);
-        $fwrite(sigmoid_file,"%f\n", out/32768.0);
-
-
-        $readmemb("../mem/central_barrel/eta1/et6/rings_data_1_et6_eta1.mem", inputs);
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Display the output
-        $display("Antes 1: %f \t Output 1: %f \t Target 1: %d",out_1_sig/32768.0, out/32768.0, targets[1]);
-        $fwrite(linear_file,"%f\n", out_1_sig/32768.0);
-        $fwrite(sigmoid_file,"%f\n", out/32768.0);
-
-
-        $readmemb("../mem/central_barrel/eta1/et6/rings_data_2_et6_eta1.mem", inputs);
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Display the output
-         $display("Antes 2: %f \t Output 2: %f \t Target 2: %d",out_1_sig/32768.0, out/32768.0, targets[2]);
-        $fwrite(linear_file,"%f\n", out_1_sig/32768.0);
-        $fwrite(sigmoid_file,"%f\n", out/32768.0);
-
-
-        $readmemb("../mem/central_barrel/eta1/et6/rings_data_3_et6_eta1.mem", inputs);
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Display the output
-        $display("Antes 3: %f \t Output 3: %f \t Target 3: %d",out_1_sig/32768.0, out/32768.0, targets[3]);
-        $fwrite(linear_file,"%f\n", out_1_sig/32768.0);
-        $fwrite(sigmoid_file,"%f\n", out/32768.0);
-
-
-        $readmemb("../mem/central_barrel/eta1/et6/rings_data_4_et6_eta1.mem", inputs);
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Display the output
-        $display("Antes 4: %f \t Output 4: %f \t Target 4: %d",out_1_sig/32768.0, out/32768.0, targets[4]);
-        $fwrite(linear_file,"%f\n", out_1_sig/32768.0);
-        $fwrite(sigmoid_file,"%f\n", out/32768.0);
-
-        $readmemb("../mem/central_barrel/eta1/et6/rings_data_5_et6_eta1.mem", inputs);
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Display the output
-         $display("Antes 5: %f \t Output 5: %f \t Target 5: %d",out_1_sig/32768.0, out/32768.0, targets[5]);
-        $fwrite(linear_file,"%f\n", out_1_sig/32768.0);
-        $fwrite(sigmoid_file,"%f\n", out/32768.0);
-
-
-        $readmemb("../mem/central_barrel/eta1/et6/rings_data_6_et6_eta1.mem", inputs);
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Display the output
-        $display("Antes 6: %f \t Output 6: %f \t Target 6: %d",out_1_sig/32768.0, out/32768.0, targets[6]);
-        $fwrite(linear_file,"%f\n", out_1_sig/32768.0);
-        $fwrite(sigmoid_file,"%f\n", out/32768.0);
-
-
-        $readmemb("../mem/central_barrel/eta1/et6/rings_data_7_et6_eta1.mem", inputs);
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Display the output
-        $display("Antes 7: %f \t Output 7: %f \t Target 7: %d",out_1_sig/32768.0, out/32768.0, targets[7]);
-        $fwrite(linear_file,"%f\n", out_1_sig/32768.0);
-        $fwrite(sigmoid_file,"%f\n", out/32768.0);
-
-
-        $readmemb("../mem/central_barrel/eta1/et6/rings_data_8_et6_eta1.mem", inputs);
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Display the output
-        $display("Antes 8: %f \t Output 8: %f \t Target 8: %d",out_1_sig/32768.0, out/32768.0, targets[8]);
-        $fwrite(linear_file,"%f\n", out_1_sig/32768.0);
-        $fwrite(sigmoid_file,"%f\n", out/32768.0);
-
-
-        $readmemb("../mem/central_barrel/eta1/et6/rings_data_9_et6_eta1.mem", inputs);
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Display the output
-        $display("Antes 9: %f \t Output 9: %f \t Target 9: %d",out_1_sig/32768.0, out/32768.0, targets[9]);
-        $fwrite(linear_file,"%f\n", out_1_sig/32768.0);
-        $fwrite(sigmoid_file,"%f\n", out/32768.0);
-
-
-        $readmemb("../mem/central_barrel/eta1/et6/rings_data_10_et6_eta1.mem", inputs);
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Display the output
-        $display("Antes 10: %f \t Output 10: %f \t Target 10: %d",out_1_sig/32768.0, out/32768.0, targets[10]);
-        $fwrite(linear_file,"%f\n", out_1_sig/32768.0);
-        $fwrite(sigmoid_file,"%f\n", out/32768.0);
-
-
-        $readmemb("../mem/central_barrel/eta1/et6/rings_data_11_et6_eta1.mem", inputs);
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Display the output
-        $display("Antes 11: %f \t Output 11: %f \t Target 11: %d",out_1_sig/32768.0, out/32768.0, targets[11]);
-        $fwrite(linear_file,"%f\n", out_1_sig/32768.0);
-        $fwrite(sigmoid_file,"%f\n", out/32768.0);
-
-
-        $readmemb("../mem/central_barrel/eta1/et6/rings_data_12_et6_eta1.mem", inputs);
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Display the output
-        $display("Antes 12: %f \t Output 12: %f \t Target 12: %d",out_1_sig/32768.0, out/32768.0, targets[12]);
-        $fwrite(linear_file,"%f\n", out_1_sig/32768.0);
-        $fwrite(sigmoid_file,"%f\n", out/32768.0);
-
-
-        $readmemb("../mem/central_barrel/eta1/et6/rings_data_13_et6_eta1.mem", inputs);
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Display the output
-        $display("Antes 13: %f \t Output 13: %f \t Target 13: %d",out_1_sig/32768.0, out/32768.0, targets[13]);
-        $fwrite(linear_file,"%f\n", out_1_sig/32768.0);
-        $fwrite(sigmoid_file,"%f\n", out/32768.0);
-
-
-        $readmemb("../mem/central_barrel/eta1/et6/rings_data_14_et6_eta1.mem", inputs);
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Display the output
-        $display("Antes 14: %f \t Output 14: %f \t Target 14: %d",out_1_sig/32768.0, out/32768.0, targets[14]);
-        $fwrite(linear_file,"%f\n", out_1_sig/32768.0);
-        $fwrite(sigmoid_file,"%f\n", out/32768.0);
-
-
-        $readmemb("../mem/central_barrel/eta1/et6/rings_data_15_et6_eta1.mem", inputs);
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Display the output
-        $display("Antes 15: %f \t Output 15: %f \t Target 15: %d",out_1_sig/32768.0, out/32768.0, targets[15]);
-        $fwrite(linear_file,"%f\n", out_1_sig/32768.0);
-        $fwrite(sigmoid_file,"%f\n", out/32768.0);
-
-
-        $readmemb("../mem/central_barrel/eta1/et6/rings_data_16_et6_eta1.mem", inputs);
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Display the output
-        $display("Antes 16: %f \t Output 16: %f \t Target 16: %d",out_1_sig/32768.0, out/32768.0, targets[16]);
-        $fwrite(linear_file,"%f\n", out_1_sig/32768.0);
-        $fwrite(sigmoid_file,"%f\n", out/32768.0);
-
-
-        $readmemb("../mem/central_barrel/eta1/et6/rings_data_17_et6_eta1.mem", inputs);
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Display the output
-        $display("Antes 17: %f \t Output 17: %f \t Target 17: %d",out_1_sig/32768.0, out/32768.0, targets[17]);
-        $fwrite(linear_file,"%f\n", out_1_sig/32768.0);
-        $fwrite(sigmoid_file,"%f\n", out/32768.0);
-
-
-        $readmemb("../mem/central_barrel/eta1/et6/rings_data_18_et6_eta1.mem", inputs);
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Display the output
-        $display("Antes 18: %f \t Output 18: %f \t Target 18: %d",out_1_sig/32768.0, out/32768.0, targets[18]);
-        $fwrite(linear_file,"%f\n", out_1_sig/32768.0);
-        $fwrite(sigmoid_file,"%f\n", out/32768.0);
-
-
-        $readmemb("../mem/central_barrel/eta1/et6/rings_data_19_et6_eta1.mem", inputs);
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Generate a positive impulse on clock
-        clock = 1; 
-        #10; 
-        clock = 0;
-        #50;
-
-        // Display the output
-        $display("Antes 19: %f \t Output 19: %f \t Target 19: %d",out_1_sig/32768.0, out/32768.0, targets[19]);
-        $fwrite(linear_file,"%f\n", out_1_sig/32768.0);
-        $fwrite(sigmoid_file,"%f\n", out/32768.0);
         $fclose(sigmoid_file);
         $fclose(linear_file);
 


### PR DESCRIPTION
Replaced repetitive $readmemb, clock impulses, and display/write statements with a for loop
that dynamically loads input files, generates clock pulses, and logs outputs, reducing code duplication.